### PR TITLE
ci: remove update supported bee version action

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -52,9 +52,3 @@ jobs:
 
       - name: Check typings
         run: npm run check:types
-
-      - name: Update supported Bee action
-        uses: ethersphere/update-supported-bee-action@v1
-        if: github.ref == 'refs/heads/master'
-        with:
-          token: ${{ secrets.REPO_GHA_PAT }}


### PR DESCRIPTION
This action requires bee-js to be a dependency and we don't use nor need bee-js in the electron.