### PR TITLE
feat: persistant logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,14 @@ Linux: `bee-desktop-0.4.0-1.x86_64.rpm` or `bee-desktop_0.4.0_amd64.deb`
 
 > You can alternatively clone this repository and run `npm install` and then `npm start`
 
+# Logs
+
+If you run the build version you can access logs of Bee Desktop at:
+
+ - macOS: `~/Library/Logs/bee-desktop-nodejs/bee-desktop.log`
+ - Windows: `%LOCALAPPDATA%\bee-desktop-nodejs\Log\bee-desktop.log` (for example, `C:\Users\USERNAME\AppData\Local\MyApp-nodejs\Log\bee-desktop.log`)
+ - Linux: `~/.local/state/bee-desktop-nodejs/bee-desktop.log`
+
 # If you have a previous installation
 
 You need to delete the previous assets first to receive updates

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -3,6 +3,7 @@ import requestStats from 'request-stats'
 import type { Server } from 'http'
 
 import { SupportedLevels, SUPPORTED_LEVELS, logLevel } from './config'
+import { getLogPath } from './path'
 
 const supportedLevels: Record<SupportedLevels, number> = SUPPORTED_LEVELS.reduce(
   (acc, cur, idx) => ({ ...acc, [cur]: idx }),
@@ -17,9 +18,16 @@ export const logger: Logger = createLogger({
     format.metadata(),
     format.timestamp(),
     format.printf(formatLogMessage),
-    format.colorize({ all: true }),
   ),
-  transports: [new transports.Console({ level: logLevel })],
+  transports: [
+    new transports.Console({ level: logLevel, format: format.colorize({ all: true }) }),
+    new transports.File({
+      filename: getLogPath('bee-desktop.log'),
+      maxsize: 1_000_000,
+      maxFiles: 10,
+      tailable: true,
+    }),
+  ],
 })
 
 logger.info(`using max log level=${logLevel}`)

--- a/src/path.ts
+++ b/src/path.ts
@@ -11,3 +11,7 @@ export function checkPath(path: string): boolean {
 export function getPath(path: string): string {
   return join(paths.data, path)
 }
+
+export function getLogPath(logFileName: string): string {
+  return join(paths.log, logFileName)
+}


### PR DESCRIPTION
This adds support to persist the Bee Desktops logs to a file as it is not possible to see the logs when running Bee Desktop from build sources.  

The size of the logs is limited to 10*1 MB files