### PR TITLE
ci: pre-release support

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -20,23 +20,14 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
+
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v1
         with:
+          cache: 'npm'
           node-version: ${{ matrix.node-version }}
 
-      ## Try getting the node modules from cache, if failed npm ci
-      - uses: actions/cache@v2
-        id: cache-npm
-        with:
-          path: node_modules
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.OS }}-node-${{ env.cache-name }}-
-            ${{ runner.OS }}-node-
-            ${{ runner.OS }}-
-      - name: Install npm deps
-        if: steps.cache-npm.outputs.cache-hit != 'true'
+      - name: Install deps
         run: npm ci
 
       - name: Commit linting

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -1,8 +1,11 @@
-name: Release
+name: Pre-release
+
 on:
-  release:
-    types:
-      - created
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Pre-release version (without "v" prefix)'
+        required: true
 
 jobs:
   publish:
@@ -21,6 +24,13 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Replace Version in package.json
+        uses: jossef/action-set-json-field@v1
+        with:
+          file: package.json
+          field: version
+          value: ${{ github.event.inputs.version }}
+
       - name: Configure secrets
         uses: jossef/action-set-json-field@v1
         with:
@@ -28,7 +38,7 @@ jobs:
           field: KEY
           value: ${{ secrets.SENTRY_KEY }}
 
-      - name: publish
+      - name: Publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: npm run publish
@@ -42,3 +52,4 @@ jobs:
           SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
         with:
           sourcemaps: ./dist/src
+          version: ${{ github.event.inputs.version }}

--- a/package.json
+++ b/package.json
@@ -70,7 +70,8 @@
             "repository": {
               "owner": "ethersphere",
               "name": "bee-desktop"
-            }
+            },
+            "prerelease": true
           }
         }
       ]


### PR DESCRIPTION
This adds support for pre-releases and incorporates a newly discovered way how to cache NPM's dependencies with the [actions/setup-node](https://github.com/actions/setup-node#caching-global-packages-data) action.

The pre-release functionality might not be clear right away, but if the `@electron-forge/publisher-github` does not find the release version in `package.json` it will create a new release. For normal releases that is not needed as we have GH release created by Release Please, but for the pre-releases the `@electron-forge/publisher-github` will be the one who will create the GH release (hence I have added the `prerelease` flag to it in config).